### PR TITLE
Libs patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,29 +3,6 @@
 version = 4
 
 [[package]]
-name = "Orinium_Browser"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64",
- "env_logger",
- "futures",
- "http",
- "log",
- "pollster",
- "rustls-native-certs",
- "sha2",
- "tokio",
- "twoway",
- "url",
- "webpki",
- "webpki-roots 0.26.11",
- "wgpu",
- "winit",
- "x509-parser",
-]
-
-[[package]]
 name = "ab_glyph"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1634,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "orinium_browser"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "env_logger",
+ "futures",
+ "http",
+ "log",
+ "pollster",
+ "rustls-native-certs",
+ "sha2",
+ "tokio",
+ "twoway",
+ "url",
+ "webpki",
+ "webpki-roots 0.26.11",
+ "wgpu",
+ "winit",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Orinium_Browser"
+name = "orinium_browser"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ pub mod engine;
 /// ファイルI/Oなどプラットフォーム固有の実装が含まれます。
 pub mod platform;
 
-// 便利な再エクスポート
 pub use engine::html;
 pub use platform::network;
-pub use engine::html::parser; // parser モジュールを直接再エクスポート
+pub use engine::html::parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+/// ブラウザのコア機能を提供するモジュール
+/// このモジュールには、HTML/CSSパーサー、DOMツリー構築、
+/// JavaScriptエンジンなどブラウザの中核となる機能が含まれます。
+pub mod engine;
+
+/// プラットフォーム依存の機能を提供するモジュール
+/// このモジュールには、ネットワーク処理、レンダリング、UI表示、
+/// ファイルI/Oなどプラットフォーム固有の実装が含まれます。
+pub mod platform;
+
+// 便利な再エクスポート
+pub use engine::html;
+pub use platform::network;
+pub use engine::html::parser; // parser モジュールを直接再エクスポート

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 use anyhow::{Result, Context};
 
-// クレートからモジュールを正しくインポート
 use orinium_browser::{parser, network};
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,8 @@
 use std::env;
-// use std::path::Path;
 use anyhow::{Result, Context};
 
-mod platform;
-mod engine;
-use engine::html::parser;
-use platform::network;
-// use platform::io;
+// クレートからモジュールを正しくインポート
+use orinium_browser::{parser, network};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
This pull request refactors the project structure to improve clarity and modularity. It reorganizes the main modules into a more idiomatic Rust layout, updates the crate name, and streamlines imports in the main entry point.

Project structure and naming improvements:

* Changed the crate name in `Cargo.toml` from `Orinium_Browser` to `orinium_browser` to follow Rust naming conventions.

Module organization and re-exports:

* Added `engine` and `platform` modules in `src/lib.rs`, grouping core browser logic and platform-specific functionality, and provided convenient re-exports for key submodules like `html`, `network`, and `parser`.

Import and usage simplification:

* Updated `src/main.rs` to import `parser` and `network` directly from the crate root, reflecting the new module structure and removing legacy import paths.