### PR TITLE
図形が描画されないバグを修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-//use orinium_browser::renderer::Color;
+use orinium_browser::engine::renderer::{Color, DrawCommand};
 use std::env;
 
 use orinium_browser::engine::html::parser::Parser;
@@ -37,8 +37,16 @@ async fn main() -> Result<()> {
 
     // レンダラーを作成して描画命令を生成
     let renderer = Renderer::new(800.0, 600.0);
-    let draw_commands = renderer.generate_draw_commands(&dom_tree);
-    //let draw_commands: Vec<DrawCommand> = vec![DrawCommand::DrawRect { x: (0f32), y: (100f32), width: (100f32), height: (100f32), color: (Color { r: (88.0), g: (88.0), b: (88.0), a: (0.5) }) }];
+    let mut draw_commands = renderer.generate_draw_commands(&dom_tree);
+
+    // テスト用の矩形を追加（色の値を0.0〜1.0の範囲に修正）
+    draw_commands.push(DrawCommand::DrawRect {
+        x: 0.0,
+        y: 100.0,
+        width: 100.0,
+        height: 100.0,
+        color: Color { r: 0.8, g: 0.2, b: 0.2, a: 1.0 }
+    });
 
     log::info!("Generated {} draw commands", draw_commands.len());
     log::info!("Generated draw commands: {:#?}", draw_commands);
@@ -46,6 +54,9 @@ async fn main() -> Result<()> {
     // ウィンドウとイベントループを作成
     let event_loop = EventLoop::<orinium_browser::platform::ui::State>::with_user_event().build()?;
     let mut app = App::new();
+
+    // 描画命令をAppに設定
+    app.set_draw_commands(draw_commands);
 
     event_loop.run_app(&mut app)?;
 


### PR DESCRIPTION
## 概要 / Summary
図形を描画しても何も出てこない問題を修正しました。
三角形の頂点の向きが間違っており、裏面除去の機能で図形が描画されてなかったので、cull_mode: Some(wgpu::Face::Back)をcull_mode: Noneに変更してカリングを無効化しました。

## 関連タスク / Related Tasks
なし

## スクリーンショット / Screenshots
<img width="799" height="631" alt="image" src="https://github.com/user-attachments/assets/912952e4-4acf-413f-9c8c-0f1421d31549" />

## 備考 / Notes
とくになし
