### PR TITLE
他のサーバーに依存するテストを無視

### DIFF
--- a/tests/network_https_test.rs
+++ b/tests/network_https_test.rs
@@ -2,6 +2,7 @@ use orinium_browser::platform::network::NetworkCore;
 use std::error::Error;
 use tokio::runtime::Runtime;
 
+#[ignore]
 #[test]
 fn test_https_connection() -> Result<(), Box<dyn Error>> {
     let rt = Runtime::new()?;
@@ -30,6 +31,7 @@ fn test_https_connection() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[ignore]
 #[test]
 fn test_http_and_https_comparison() -> Result<(), Box<dyn Error>> {
     let rt = Runtime::new()?;
@@ -75,6 +77,7 @@ fn test_http_and_https_comparison() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[ignore]
 #[test]
 fn test_https_redirect() -> Result<(), Box<dyn Error>> {
     let rt = Runtime::new()?;


### PR DESCRIPTION
## 概要 / Summary
https://github.com/orinium-browser/orinium/actions/runs/19062273732
https://github.com/orinium-browser/orinium/actions/runs/19062277108
の修正

## 関連タスク / Related Tasks
- #68 

## 備考 / Notes
ネットワークに依存するテストを無視するように設定しました。