### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "dev" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/orinium-browser/orinium/security/code-scanning/3](https://github.com/orinium-browser/orinium/security/code-scanning/3)

In general, this issue is fixed by adding an explicit `permissions` block either at the top workflow level (to apply to all jobs that don’t override it) or directly under the specific job. For this workflow, the job only checks out code and runs `cargo check`, so it needs only read access to repository contents. Therefore, we should restrict the `GITHUB_TOKEN` to `contents: read`.

The best minimal fix without changing functionality is to add a workflow-level `permissions` block near the top (e.g., after `name` or after `on`) with `contents: read`. This keeps the behavior of the `build` job unchanged while ensuring that all jobs in this workflow (currently just `build`) run with least privilege. Concretely, in `.github/workflows/rust-check.yml`, add:

```yaml
permissions:
  contents: read
```

at the top workflow level (aligned with `name` and `on`). No additional imports, methods, or definitions are needed because this is a declarative change to the GitHub Actions YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
