### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/orinium-browser/orinium/security/code-scanning/2](https://github.com/orinium-browser/orinium/security/code-scanning/2)

In general, the problem is fixed by adding an explicit `permissions` block with least-privilege settings either at the top level of the workflow (applies to all jobs) or within the specific job. Since this workflow only needs to read repository contents to build and test, `contents: read` is sufficient. Declaring this ensures the `GITHUB_TOKEN` cannot perform unintended write operations even if repository defaults are broad.

The best fix here is to add a root-level `permissions` block just under the `name: Rust` line (or anywhere at the top level before `jobs:`) so it applies to all current and future jobs unless overridden. We’ll set it to:

```yml
permissions:
  contents: read
```

No imports or additional definitions are required; this is purely a YAML configuration change within `.github/workflows/rust.yml`. Existing functionality (checkout, build, test) will continue to work, because they only require read access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
