### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/warm-master-pr.yml
+++ b/.github/workflows/warm-master-pr.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   warn:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       AUTHOR: ${{ github.event.pull_request.user.login }}
       TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Potential fix for [https://github.com/orinium-browser/orinium/security/code-scanning/1](https://github.com/orinium-browser/orinium/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required by this workflow, either at the workflow root (affecting all jobs) or on the specific job. This documents the intended permissions and prevents the `GITHUB_TOKEN` from inheriting potentially broader repository defaults.

For this specific workflow, the `warn` job needs to: (1) read repository and pull request metadata (covered by `contents: read` and implicit read scopes), and (2) post a comment on the pull request via `github.rest.issues.createComment`, which requires the ability to write to issues/PRs. The most precise minimal set is to grant `contents: read` and `pull-requests: write`. We can define this at the job level so it is scoped just to `warn`. No imports or additional methods are needed since this is a YAML configuration file.

You should edit `.github/workflows/warm-master-pr.yml` and insert a `permissions` block under the `warn` job (between `runs-on` and `env` is a natural place). No other changes to functionality or logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
