### PR TITLE
Add pixi_byte dependency from GitHub (#163)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ url = "2.5"
 wgpu = "29.0.1"
 wgpu-types = "29.0.1"
 winit = "0.30.13"
+pixi_byte = { git = "https://github.com/orinium-browser/pixi_byte", branch = "dev" }
 
 [dev-dependencies]
 colored = "3.1.1"  # コマンドラインハイライト用


### PR DESCRIPTION
## 概要 / Summary
JSエンジンである `pixi_byte` を `Cargo.toml` の依存関係（dependencies）に追加しました。

## 関連タスク / Related Tasks
- #163 のタスクに対応

## 備考 / Notes
JSエンジンの導入に向けた最初のステップ（基本設定）となります。
