### PR TITLE
Orinium text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ dependencies = [
  "image",
  "log",
  "once_cell",
+ "orinium_text",
  "pollster",
  "rustls",
  "rustls-native-certs",
@@ -2459,6 +2460,18 @@ dependencies = [
  "wgpu",
  "wgpu-types",
  "winit",
+]
+
+[[package]]
+name = "orinium_text"
+version = "0.1.0"
+source = "git+https://github.com/orinium-browser/orinium_text?rev=27294a184abee6e2b993c25ba3f2678d86644d6a#27294a184abee6e2b993c25ba3f2678d86644d6a"
+dependencies = [
+ "fontdb",
+ "fontdue",
+ "rustybuzz",
+ "unicode-bidi",
+ "unicode-linebreak",
 ]
 
 [[package]]
@@ -3066,6 +3079,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "same-file"
@@ -3806,6 +3837,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3859,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -4836,3 +4885,7 @@ checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
+
+[[patch.unused]]
+name = "orinium_text"
+version = "0.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,30 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe782a9e7520cc7de2232c957a47f99d3a35e855552677d07a557bc1a3b66ed"
-dependencies = [
- "bitflags 2.11.1",
- "fontdb",
- "harfrust",
- "linebender_resource_handle",
- "log",
- "rangemap",
- "rustc-hash 2.1.2",
- "self_cell",
- "skrifa",
- "smol_str 0.3.6",
- "swash",
- "sys-locale",
- "unicode-bidi",
- "unicode-linebreak",
- "unicode-script",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cpal"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +731,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thousands",
@@ -984,15 +960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,19 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glyphon"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dde9640ec6f986f59a265b4c0a5177f61e87e3ba71983b2195dab119cda0fa"
-dependencies = [
- "cosmic-text",
- "etagere",
- "lru",
- "rustc-hash 2.1.2",
- "wgpu",
-]
-
-[[package]]
 name = "gpu-allocator"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,19 +1217,6 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
-]
-
-[[package]]
-name = "harfrust"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9"
-dependencies = [
- "bitflags 2.11.1",
- "bytemuck",
- "core_maths",
- "read-fonts",
- "smallvec",
 ]
 
 [[package]]
@@ -1771,12 +1712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,12 +1758,6 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "mach2"
@@ -1921,7 +1850,7 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -2438,8 +2367,8 @@ dependencies = [
  "dhat",
  "entities",
  "env_logger",
+ "etagere",
  "fontdue",
- "glyphon",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2760,12 +2689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
-name = "rangemap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
-
-[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,17 +2774,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "core_maths",
- "font-types",
 ]
 
 [[package]]
@@ -2969,12 +2881,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3164,12 +3070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,16 +3154,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
 
 [[package]]
 name = "slab"
@@ -3384,17 +3274,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "swash"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
-dependencies = [
- "skrifa",
- "yazi",
- "zeno",
-]
 
 [[package]]
 name = "symphonia"
@@ -3577,15 +3456,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sys-locale"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3827,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "ui_layout"
 version = "0.10.0"
-source = "git+https://github.com/098orin/ui_layout-rs?rev=c58a2648c8cc75d971e611827819103858ed4cef#c58a2648c8cc75d971e611827819103858ed4cef"
+source = "git+https://github.com/098orin/ui_layout-rs?rev=369a67e0a7ce00e51422a164f458f26101165aa3#369a67e0a7ce00e51422a164f458f26101165aa3"
 
 [[package]]
 name = "unicode-bidi"
@@ -4206,7 +4076,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
@@ -4741,12 +4611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
-name = "yazi"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4768,12 +4632,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "zeno"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,7 @@ dependencies = [
 [[package]]
 name = "orinium_text"
 version = "0.1.0"
+source = "git+https://github.com/orinium-browser/orinium_text?rev=53ed52fb807919a07a6516e05dd6b9c3d81039bb#53ed52fb807919a07a6516e05dd6b9c3d81039bb"
 dependencies = [
  "fontdb",
  "fontdue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,6 @@ dependencies = [
 [[package]]
 name = "orinium_text"
 version = "0.1.0"
-source = "git+https://github.com/orinium-browser/orinium_text?rev=27294a184abee6e2b993c25ba3f2678d86644d6a#27294a184abee6e2b993c25ba3f2678d86644d6a"
 dependencies = [
  "fontdb",
  "fontdue",
@@ -4885,7 +4884,3 @@ checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "orinium_text"
-version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ bytemuck = { version = "1.25", features = ["derive"] }
 cpal = "0.17.3"
 entities = "1.0.1"
 env_logger = "0.11.10"
+etagere = "0.3.0"
 fontdue = "0.9.3"
-glyphon = "0.11.0"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
@@ -42,7 +42,7 @@ tokio = { version = "1.52", features = ["fs", "io-std", "net", "rt", "time"] }
 tokio-rustls = "0.26.4"
 ui_layout = {
   git = "https://github.com/098orin/ui_layout-rs",
-  rev = "c58a2648c8cc75d971e611827819103858ed4cef"
+  rev = "369a67e0a7ce00e51422a164f458f26101165aa3"
 }
 url = "2.5"
 wgpu = "29.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ resolver = "3"
 [dependencies]
 dhat = "0.3.3"
 
-orinium_text = { path = "../orinium_text" }
-# orinium_text = {
-#   git = "https://github.com/orinium-browser/orinium_text",
-#   rev = "27294a184abee6e2b993c25ba3f2678d86644d6a",
-# }
+# orinium_text = { path = "../orinium_text" }
+orinium_text = {
+  git = "https://github.com/orinium-browser/orinium_text",
+  rev = "53ed52fb807919a07a6516e05dd6b9c3d81039bb",
+}
 
 ab_glyph = "0.2"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ resolver = "3"
 [dependencies]
 dhat = "0.3.3"
 
+orinium_text = {
+  git = "https://github.com/orinium-browser/orinium_text",
+  rev = "27294a184abee6e2b993c25ba3f2678d86644d6a",
+}
+
 ab_glyph = "0.2"
 anyhow = "1.0"
 bytemuck = { version = "1.25", features = ["derive"] }
@@ -49,3 +54,6 @@ strsim = "0.11.1"
 
 [features]
 dhat-heap = []
+
+[patch.crates-io]
+orinium_text = { path = "../orinium_text" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ resolver = "3"
 [dependencies]
 dhat = "0.3.3"
 
-orinium_text = {
-  git = "https://github.com/orinium-browser/orinium_text",
-  rev = "27294a184abee6e2b993c25ba3f2678d86644d6a",
-}
+orinium_text = { path = "../orinium_text" }
+# orinium_text = {
+#   git = "https://github.com/orinium-browser/orinium_text",
+#   rev = "27294a184abee6e2b993c25ba3f2678d86644d6a",
+# }
 
 ab_glyph = "0.2"
 anyhow = "1.0"
@@ -54,6 +55,3 @@ strsim = "0.11.1"
 
 [features]
 dhat-heap = []
-
-[patch.crates-io]
-orinium_text = { path = "../orinium_text" }

--- a/resource/licence/licence.html
+++ b/resource/licence/licence.html
@@ -41,20 +41,19 @@
             <h1>Third Party Licenses</h1>
             <p>This page lists the licenses of the projects used in cargo-about.</p>
         </div>
-    
+
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (307)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (319)</li>
             <li><a href="#MIT">MIT License</a> (97)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (7)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (14)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (5)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (4)</li>
             <li><a href="#Zlib">zlib License</a> (3)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (1)</li>
             <li><a href="#NCSA">University of Illinois/NCSA Open Source License</a> (1)</li>
-            <li><a href="#OpenSSL">OpenSSL License</a> (1)</li>
         </ul>
 
         <h2>All license text:</h2>
@@ -484,8 +483,9 @@
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/psychon/as-raw-xcb-connection ">as-raw-xcb-connection 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-windowing/raw-window-metal ">raw-window-metal 1.1.0</a></li>
                     <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
-                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.10.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                     <li><a href=" https://github.com/psychon/x11rb ">x11rb-protocol 0.13.2</a></li>
                     <li><a href=" https://github.com/psychon/x11rb ">x11rb 0.13.2</a></li>
@@ -699,205 +699,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeffparsons/rangemap ">rangemap 1.7.1</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2019-2022 Jeff Parsons, and [contributors](https://github.com/jeffparsons/rangemap/contributors)
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.3.2</a></li>
@@ -905,42 +706,31 @@
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.59.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.3.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-registry 0.6.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1359,8 +1149,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.31</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.31</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.48</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1779,8 +1569,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awxkee/moxcms.git ">moxcms 0.7.11</a></li>
-                    <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.27</a></li>
+                    <li><a href=" https://github.com/awxkee/moxcms.git ">moxcms 0.8.1</a></li>
+                    <li><a href=" https://github.com/awxkee/pxfm ">pxfm 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1989,12 +1779,13 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.12.0</a></li>
-                    <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.0</a></li>
-                    <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
+                    <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.13.1</a></li>
+                    <li><a href=" https://github.com/RustAudio/cpal ">cpal 0.17.3</a></li>
+                    <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.1</a></li>
+                    <li><a href=" https://github.com/garypen/mintex ">mintex 0.1.4</a></li>
                     <li><a href=" https://github.com/axelf4/unicode-linebreak ">unicode-linebreak 0.1.5</a></li>
-                    <li><a href=" https://github.com/etemesi254/zune-image ">zune-core 0.5.0</a></li>
-                    <li><a href=" https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg ">zune-jpeg 0.5.8</a></li>
+                    <li><a href=" https://github.com/etemesi254/zune-image ">zune-core 0.5.1</a></li>
+                    <li><a href=" https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg ">zune-jpeg 0.5.15</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2177,424 +1968,6 @@
 
       To apply the Apache License to your work, attach the following
       boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2017 Juniper Networks, Inc.
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/pop-os/cosmic-text ">cosmic-text 0.15.0</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
       replaced with your own identifying information. (Don&#x27;t include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -2830,26 +2203,27 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
-                    <li><a href=" https://github.com/bbqsrc/core2 ">core2 0.4.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.10</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-macros 0.2.3</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.3.1</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types 0.5.0</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-jni-sys ">jni-sys 0.3.0</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
+                    <li><a href=" https://github.com/wcampbell0x2a/no-std-io2 ">no_std_io2 0.9.4</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                     <li><a href=" http://github.com/tailhook/quick-error ">quick-error 2.0.1</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.10+spec-1.0.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.11+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3268,11 +2642,431 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.31</a></li>
+                    <li><a href=" https://crates.io/crates/orinium_text ">orinium_text 0.1.0</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Orinium Developer Team 098orin
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/ejmahler/RustFFT ">rustfft 6.4.1</a></li>
+                    <li><a href=" http://github.com/ejmahler/strength_reduce ">strength_reduce 0.2.4</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -3900,215 +3694,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang-nursery/pin-utils ">pin-utils 0.1.0</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2018 The pin-utils authors
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86 0.2.21</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -4527,7 +4112,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.13.2</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4736,7 +4321,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4945,7 +4530,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/image-rs/image-gif ">gif 0.14.1</a></li>
+                    <li><a href=" https://github.com/image-rs/image-gif ">gif 0.14.2</a></li>
                     <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -5154,7 +4739,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/grovesNL/glyphon ">glyphon 0.10.0</a></li>
+                    <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                     <li><a href=" https://github.com/rust-embedded-community/aligned ">aligned 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
@@ -5162,21 +4747,21 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/japaric/as-slice ">as-slice 0.2.1</a></li>
                     <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
-                    <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
-                    <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 4.9.0</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.50</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
+                    <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 4.10.0</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.62</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.57</a></li>
+                    <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.9.4</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-graphics-types 0.1.3</a></li>
-                    <li><a href=" https://github.com/servo/core-foundation-rs ">core-graphics-types 0.2.0</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-graphics 0.23.2</a></li>
+                    <li><a href=" https://github.com/RustAudio/coreaudio-rs.git ">coreaudio-rs 0.14.2</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
@@ -5184,83 +4769,95 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
-                    <li><a href=" https://github.com/servo/euclid ">euclid 0.22.11</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.5</a></li>
-                    <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.5</a></li>
+                    <li><a href=" https://github.com/servo/euclid ">euclid 0.22.14</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
                     <li><a href=" https://codeberg.org/swsnr/gethostname.rs.git ">gethostname 1.1.0</a></li>
+                    <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
-                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.12.1</a></li>
+                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.2</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.21.1</a></li>
                     <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.83</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
-                    <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.10</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
+                    <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
+                    <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
-                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
-                    <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.33.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.30</a></li>
                     <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
+                    <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.4.6</a></li>
                     <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
                     <li><a href=" https://github.com/rust-num/num-rational ">num-rational 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
-                    <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.6</a></li>
+                    <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
+                    <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
-                    <li><a href=" https://github.com/image-rs/image-png ">png 0.18.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
+                    <li><a href=" https://github.com/randomites/plain ">plain 0.2.3</a></li>
+                    <li><a href=" https://github.com/image-rs/image-png ">png 0.18.1</a></li>
                     <li><a href=" https://github.com/smol-rs/polling ">polling 3.11.0</a></li>
                     <li><a href=" https://github.com/zesterer/pollster ">pollster 0.4.0</a></li>
+                    <li><a href=" https://github.com/huonw/primal ">primal-check 0.3.4</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.8</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.2</a></li>
+                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-lite 0.1.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                     <li><a href=" https://github.com/ebkalderon/renderdoc-rs ">renderdoc-sys 1.1.0</a></li>
                     <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
+                    <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.3</a></li>
-                    <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.2</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.35</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
+                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
-                    <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.7</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
+                    <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
                     <li><a href=" https://github.com/rust-analyzer/smol_str ">smol_str 0.2.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/rust-analyzer/tree/master/lib/smol_str ">smol_str 0.3.6</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
-                    <li><a href=" https://github.com/dfrg/swash ">swash 0.2.6</a></li>
-                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
-                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.6.1</a></li>
+                    <li><a href=" https://github.com/tov/thousands-rs ">thousands 0.2.0</a></li>
                     <li><a href=" https://github.com/RazrFalcon/ttf-parser ">ttf-parser 0.21.1</a></li>
                     <li><a href=" https://github.com/harfbuzz/ttf-parser ">ttf-parser 0.25.1</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/unicode-bidi-mirroring ">unicode-bidi-mirroring 0.4.0</a></li>
                     <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
-                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/unicode-ccc ">unicode-ccc 0.4.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-properties ">unicode-properties 0.1.4</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
-                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.7</a></li>
+                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.56</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.106</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.106</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.106</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.106</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.83</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.46.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.3+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.71</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.98</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5469,8 +5066,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.8.0</a></li>
-                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.8.0</a></li>
+                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.9.1</a></li>
+                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.9.1</a></li>
                     <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 1.2.1</a></li>
                     <li><a href=" https://github.com/EmbarkStudios/presser ">presser 0.3.1</a></li>
                     <li><a href=" https://github.com/aldanor/qoi-rust ">qoi 0.4.1</a></li>
@@ -5682,7 +5279,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.3</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6087,7 +5684,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/oyvindln/adler2 ">adler2 2.0.1</a></li>
-                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6505,7 +6102,216 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/grovesNL/glow ">glow 0.16.0</a></li>
+                    <li><a href=" https://github.com/ejmahler/transpose ">transpose 0.2.3</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2022 The transpose developers
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/grovesNL/glow ">glow 0.17.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6713,216 +6519,6 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dfrg/yazi ">yazi 0.2.1</a></li>
-                    <li><a href=" https://github.com/dfrg/zeno ">zeno 0.3.3</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/ash-rs/ash ">ash 0.38.0+1.3.281</a></li>
                 </ul>
                 <pre class="license-text">Apache License
@@ -6964,7 +6560,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 You must give any other recipients of the Work or Derivative Works a copy of this License; and
 You must cause any modified files to carry prominent notices stating that You changed the files; and
 You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
 
 You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
@@ -6980,83 +6576,6 @@ You may add Your own copyright statement to Your modifications and may provide a
 END OF TERMS AND CONDITIONS
 
 Copyright 2016 Maik Klein
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.10.1</a></li>
-                    <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.35.0</a></li>
-                    <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.37.0</a></li>
-                </ul>
-                <pre class="license-text">Apache License
-
-Version 2.0, January 2004
-
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-&quot;License&quot; shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-&quot;Licensor&quot; shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-&quot;Legal Entity&quot; shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, &quot;control&quot; means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-&quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-&quot;Source&quot; form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-&quot;Object&quot; form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-&quot;Work&quot; shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-&quot;Derivative Works&quot; shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-&quot;Contribution&quot; shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, &quot;submitted&quot; means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-&quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of this License; and
-You must cause any modified files to carry prominent notices stating that You changed the files; and
-You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-If the Work includes a &quot;NOTICE&quot; text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
-
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-Copyright 2019 Colin Rothfels
 
 Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
 you may not use this file except in compliance with the License.
@@ -7285,7 +6804,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
-                    <li><a href=" https://github.com/rust-windowing/winit ">winit 0.30.12</a></li>
+                    <li><a href=" https://github.com/rust-windowing/winit ">winit 0.30.13</a></li>
                 </ul>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -7493,7 +7012,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.24.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.0</a></li>
                     <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck_derive 1.10.2</a></li>
                 </ul>
                 <pre class="license-text">Apache License
@@ -7563,222 +7082,18 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/pyfisch/httpdate ">httpdate 1.0.3</a></li>
-                </ul>
-                <pre class="license-text">Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-&quot;License&quot; shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
-
-&quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
-
-&quot;Legal Entity&quot; shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-&quot;control&quot; means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-&quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-exercising permissions granted by this License.
-
-&quot;Source&quot; form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
-
-&quot;Object&quot; form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
-
-&quot;Work&quot; shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
-
-&quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
-
-&quot;Contribution&quot; shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-&quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
-
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
-
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
-
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
-
-(d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
-
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-replaced with your own identifying information. (Don&#x27;t include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same &quot;printed page&quot; as the copyright notice for easier
-identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                     <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
-                    <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.0</a></li>
+                    <li><a href=" https://github.com/diwic/alsa-rs ">alsa 0.11.0</a></li>
+                    <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.1</a></li>
                     <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                     <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
+                    <li><a href=" https://github.com/rustaudio/sample.git ">dasp_sample 0.11.0</a></li>
+                    <li><a href=" https://github.com/nnethercote/dhat-rs ">dhat 0.3.3</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">dispatch2 0.3.1</a></li>
                     <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                     <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
                     <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
@@ -7789,63 +7104,72 @@ limitations under the License.
                     <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor 0.3.2</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
                     <li><a href=" https://github.com/image-rs/image-webp ">image-webp 0.2.4</a></li>
-                    <li><a href=" https://github.com/image-rs/image ">image 0.25.9</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.16</a></li>
+                    <li><a href=" https://github.com/image-rs/image ">image 0.25.10</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
                     <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.178</a></li>
-                    <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
+                    <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.5.0</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">naga 28.0.0</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">naga 29.0.3</a></li>
                     <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
                     <li><a href=" https://github.com/rust-mobile/ndk ">ndk-sys 0.6.0+11769913</a></li>
                     <li><a href=" https://github.com/rust-mobile/ndk ">ndk 0.9.0</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-audio-toolbox 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-avf-audio 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-audio-types 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-audio 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-metal 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-quartz-core 0.3.2</a></li>
                     <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/as1100k/pastey ">pastey 0.1.1</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.4</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.12.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.103</a></li>
-                    <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.17</a></li>
-                    <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.42</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.12</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.12</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
+                    <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.18</a></li>
+                    <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.18</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.4</a></li>
+                    <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.5</a></li>
                     <li><a href=" https://github.com/rust-windowing/raw-window-handle ">raw-window-handle 0.6.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                    <li><a href=" https://github.com/Voultapher/self_cell ">self_cell 1.2.1</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.149</a></li>
                     <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
+                    <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
+                    <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.4.0+sdk-1.4.341.0</a></li>
                     <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.111</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.17</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.1+wasi-0.2.4</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-hal 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 28.0.0</a></li>
-                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu 28.0.0</a></li>
-                    <li><a href=" https://crates.io/crates/zune-core ">zune-core 0.4.12</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-hal 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-naga-bridge 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 29.0.3</a></li>
+                    <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu 29.0.3</a></li>
                     <li><a href=" https://crates.io/crates/zune-inflate ">zune-inflate 0.2.54</a></li>
-                    <li><a href=" https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg ">zune-jpeg 0.4.21</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -8059,7 +7383,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/kornelski/avif-serialize ">avif-serialize 0.8.6</a></li>
+                    <li><a href=" https://github.com/kornelski/avif-serialize ">avif-serialize 0.8.9</a></li>
                 </ul>
                 <pre class="license-text">BSD 3-Clause License
 
@@ -8096,7 +7420,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/kornelski/cavif-rs ">ravif 0.12.0</a></li>
+                    <li><a href=" https://github.com/kornelski/cavif-rs ">ravif 0.13.0</a></li>
                 </ul>
                 <pre class="license-text">BSD 3-Clause License
 
@@ -8202,7 +7526,7 @@ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
             </li>
             <li class="license">
@@ -8243,9 +7567,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                     <li><a href=" https://github.com/johannesvollmer/exrs ">exr 1.74.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
+                <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -8391,38 +7716,6 @@ express Statement of Purpose.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a></li>
-                </ul>
-                <pre class="license-text">/* Copyright (c) 2018, Google Inc.
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
- * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
-
-#include &lt;openssl/crypto.h&gt;
-
-#include &lt;gtest/gtest.h&gt;
-
-
-TEST(SelfTests, KAT) {
-#if !defined(_MSC_VER)
-  EXPECT_TRUE(BORINGSSL_self_test());
-#endif
-}
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="ISC">ISC License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -8464,7 +7757,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.8</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a></li>
                 </ul>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -8491,7 +7784,8 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.3</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
                 </ul>
                 <pre class="license-text">ISC License:
 
@@ -8507,7 +7801,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/harfbuzz/harfrust ">harfrust 0.3.2</a></li>
+                    <li><a href=" https://github.com/harfbuzz/rustybuzz ">rustybuzz 0.20.1</a></li>
                 </ul>
                 <pre class="license-text">    MIT License
 
@@ -8536,7 +7830,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -8591,9 +7885,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.10.1</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -8618,14 +7912,14 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.11</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.11</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.11</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.9</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.9</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.9</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.7</a></li>
-                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.7</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.15</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.14</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.14</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.12</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.12</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.12</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.10</a></li>
+                    <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Elinor Berger
 
@@ -8653,7 +7947,7 @@ THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/mbrubeck/rust-debug-unreachable ">new_debug_unreachable 1.0.6</a></li>
-                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.1.0</a></li>
+                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -8686,7 +7980,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/elinorbgr/dlib ">dlib 0.5.2</a></li>
+                    <li><a href=" https://github.com/elinorbgr/dlib ">dlib 0.5.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Victor Berger
 
@@ -8712,7 +8006,7 @@ THE SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a></li>
+                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -8784,7 +8078,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.12</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -8817,7 +8111,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -8960,7 +8254,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/slab ">slab 0.4.11</a></li>
+                    <li><a href=" https://github.com/tokio-rs/slab ">slab 0.4.12</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Carl Lerche
 
@@ -8997,40 +8291,6 @@ DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.3</a></li>
-                    <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2019 Tower Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -9207,7 +8467,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.19</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.20</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
 
@@ -9249,18 +8509,16 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.16.2</a></li>
+                    <li><a href=" https://github.com/depp/extended-rs ">extended 0.1.0</a></li>
                 </ul>
-                <pre class="license-text">MIT License
+                <pre class="license-text">Copyright 2022 Dietrich Epp
 
-Copyright (c) 2016 Jerome Froelich
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the &quot;Software&quot;), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
@@ -9271,7 +8529,23 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/pdf-rs/fax ">fax 0.2.7</a></li>
+                </ul>
+                <pre class="license-text">Copyright © 2021 The pdf-rs contributers.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -9365,7 +8639,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/image-rs/image-tiff ">tiff 0.10.3</a></li>
+                    <li><a href=" https://github.com/image-rs/image-tiff ">tiff 0.11.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9394,7 +8668,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.52</a></li>
+                    <li><a href=" https://github.com/diwic/alsa-sys ">alsa-sys 0.4.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2018 diwic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.53</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9457,36 +8760,6 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2019 Multimedia and Rust
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Yoshua Wuyts
-Copyright (c) Tokio Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -9673,7 +8946,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.11</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.16</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9760,20 +9033,48 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/098orin/ui_layout-rs ">ui_layout 0.10.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2026 098orin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/madsmtm/objc2 ">block2 0.5.1</a></li>
-                    <li><a href=" http://github.com/SSheldon/rust-block ">block 0.1.6</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">block2 0.6.2</a></li>
                     <li><a href=" http://github.com/SSheldon/rust-dispatch ">dispatch 0.2.0</a></li>
                     <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
-                    <li><a href=" https://github.com/pdf-rs/fax ">fax 0.2.6</a></li>
-                    <li><a href=" https://github.com/pdf-rs/fax ">fax_derive 0.2.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.15</a></li>
-                    <li><a href=" https://github.com/SSheldon/malloc_buf ">malloc_buf 0.0.6</a></li>
+                    <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc-sys 0.3.5</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.2.2</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc2-encode 4.1.0</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc2-foundation 0.2.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-foundation 0.3.2</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc2-ui-kit 0.2.2</a></li>
                     <li><a href=" https://github.com/madsmtm/objc2 ">objc2 0.5.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2 0.6.4</a></li>
                     <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -9800,37 +9101,8 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" http://github.com/SSheldon/rust-objc ">objc 0.2.7</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) Steven Sheldon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.17</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.48.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9859,7 +9131,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a></li>
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -9918,6 +9190,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
+                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -9948,7 +9221,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.2</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -10005,8 +9278,8 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.4</a></li>
                     <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.17</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -10097,7 +9370,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.49</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.54</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -10132,6 +9405,36 @@ SOFTWARE.
 
 Copyright (c) 2015-2019 PistonDevelopers
 Copyright (c) 2019 image-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.40.0</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -10302,7 +9605,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.37.5</a></li>
+                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.3</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -10348,7 +9651,19 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mackwic/colored ">colored 3.0.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-bundle-flac 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-bundle-mp3 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-codec-aac 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-codec-adpcm 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-codec-pcm 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-codec-vorbis 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-common 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-core 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-format-mkv 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-format-ogg 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-format-riff 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia-metadata 0.6.0</a></li>
+                    <li><a href=" https://github.com/pdeljanov/Symphonia ">symphonia 0.6.0</a></li>
                 </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -10387,7 +9702,387 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
     means any form of the work other than Source Code Form.
 
 1.7. &quot;Larger Work&quot;
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. &quot;License&quot;
+    means this document.
+
+1.9. &quot;Licensable&quot;
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. &quot;Modifications&quot;
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. &quot;Patent Claims&quot; of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. &quot;Secondary License&quot;
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. &quot;Source Code Form&quot;
+    means the form of the work preferred for making modifications.
+
+1.14. &quot;You&quot; (or &quot;Your&quot;)
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, &quot;You&quot; includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, &quot;control&quot; means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party&#x27;s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients&#x27; rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients&#x27; rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an &quot;as is&quot;       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party&#x27;s negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party&#x27;s ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
+---------------------------------------------------------
+
+  This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
+  defined by the Mozilla Public License, v. 2.0.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mackwic/colored ">colored 3.1.1</a></li>
+                </ul>
+                <pre class="license-text">Mozilla Public License Version 2.0
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+1. Definitions
+--------------
+
+1.1. &quot;Contributor&quot;
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. &quot;Contributor Version&quot;
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor&#x27;s Contribution.
+
+1.3. &quot;Contribution&quot;
+    means Covered Software of a particular Contributor.
+
+1.4. &quot;Covered Software&quot;
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. &quot;Incompatible With Secondary Licenses&quot;
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. &quot;Executable Form&quot;
+    means any form of the work other than Source Code Form.
+
+1.7. &quot;Larger Work&quot;
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. &quot;License&quot;
@@ -10729,7 +10424,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="NCSA">University of Illinois/NCSA Open Source License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.10</a></li>
+                    <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
                 </ul>
                 <pre class="license-text">University of Illinois/NCSA Open Source License
 
@@ -10749,184 +10444,10 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 </pre>
             </li>
             <li class="license">
-                <h3 id="OpenSSL">OpenSSL License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a></li>
-                </ul>
-                <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
- * All rights reserved.
- *
- * This package is an SSL implementation written
- * by Eric Young (eay@cryptsoft.com).
- * The implementation was written so as to conform with Netscapes SSL.
- *
- * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
- * apply to all code found in this distribution, be it the RC4, RSA,
- * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
- * included with this distribution is covered by the same copyright terms
- * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- *
- * Copyright remains Eric Young&#x27;s, and as such any Copyright notices in
- * the code are not to be removed.
- * If this package is used in a product, Eric Young should be given attribution
- * as the author of the parts of the library used.
- * This can be in the form of a textual message at program startup or
- * in documentation (online or textual) provided with the package.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *    &quot;This product includes cryptographic software written by
- *     Eric Young (eay@cryptsoft.com)&quot;
- *    The word &#x27;cryptographic&#x27; can be left out if the rouines from the library
- *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from
- *    the apps directory (application code) you must include an acknowledgement:
- *    &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;
- *
- * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#x60;&#x60;AS IS&#x27;&#x27; AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * The licence and distribution terms for any publically available version or
- * derivative of this code cannot be changed.  i.e. this code cannot simply be
- * copied and put under another distribution licence
- * [including the GNU Public Licence.]
- */
-/* &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
- * Copyright (c) 1998-2007 The OpenSSL Project.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- * 3. All advertising materials mentioning features or use of this
- *    software must display the following acknowledgment:
- *    &quot;This product includes software developed by the OpenSSL Project
- *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
- *
- * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to
- *    endorse or promote products derived from this software without
- *    prior written permission. For written permission, please contact
- *    openssl-core@openssl.org.
- *
- * 5. Products derived from this software may not be called &quot;OpenSSL&quot;
- *    nor may &quot;OpenSSL&quot; appear in their names without prior written
- *    permission of the OpenSSL Project.
- *
- * 6. Redistributions of any form whatsoever must retain the following
- *    acknowledgment:
- *    &quot;This product includes software developed by the OpenSSL Project
- *    for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
- *
- * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY
- * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
- * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
- * &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
- *
- * This product includes cryptographic software written by Eric Young
- * (eay@cryptsoft.com).  This product includes software written by Tim
- * Hudson (tjh@cryptsoft.com).
- *
- */
-
-#include &lt;openssl/ssl.h&gt;
-
-#if !defined(OPENSSL_WINDOWS) &amp;&amp; !defined(OPENSSL_PNACL) &amp;&amp; \
-    !defined(OPENSSL_NO_FILESYSTEM)
-
-#include &lt;dirent.h&gt;
-#include &lt;errno.h&gt;
-#include &lt;string.h&gt;
-
-#include &lt;openssl/err.h&gt;
-#include &lt;openssl/mem.h&gt;
-
-
-int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
-                                       const char *path) {
-  DIR *dir &#x3D; opendir(path);
-  if (dir &#x3D;&#x3D; NULL) {
-    OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
-    ERR_add_error_data(3, &quot;opendir(&#x27;&quot;, dir, &quot;&#x27;)&quot;);
-    return 0;
-  }
-
-  int ret &#x3D; 0;
-  for (;;) {
-    // |readdir| may fail with or without setting |errno|.
-    errno &#x3D; 0;
-    struct dirent *dirent &#x3D; readdir(dir);
-    if (dirent &#x3D;&#x3D; NULL) {
-      if (errno) {
-        OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
-        ERR_add_error_data(3, &quot;readdir(&#x27;&quot;, path, &quot;&#x27;)&quot;);
-      } else {
-        ret &#x3D; 1;
-      }
-      break;
-    }
-
-    char buf[1024];
-    if (strlen(path) + strlen(dirent-&gt;d_name) + 2 &gt; sizeof(buf)) {
-      OPENSSL_PUT_ERROR(SSL, SSL_R_PATH_TOO_LONG);
-      break;
-    }
-
-    int r &#x3D; snprintf(buf, sizeof(buf), &quot;%s/%s&quot;, path, dirent-&gt;d_name);
-    if (r &lt;&#x3D; 0 ||
-        r &gt;&#x3D; (int)sizeof(buf) ||
-        !SSL_add_file_cert_subjects_to_stack(stack, buf)) {
-      break;
-    }
-  }
-
-  closedir(dir);
-  return ret;
-}
-
-#endif  // !WINDOWS &amp;&amp; !PNACL &amp;&amp; !OPENSSL_NO_FILESYSTEM
-</pre>
-            </li>
-            <li class="license">
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -10973,24 +10494,24 @@ authorization of the copyright holder.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.3</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.7</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.4</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.6</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 

--- a/src/engine/bridge/text/fallback.rs
+++ b/src/engine/bridge/text/fallback.rs
@@ -1,7 +1,7 @@
 //! Fallback text measurer without font engine dependency.
 
-use super::{TextMeasureError, TextMeasureRequest, TextMeasurer, TextMetrics};
-use crate::engine::layouter::types::TextStyle;
+use super::{TextMeasureError, TextMeasureRequest, TextMeasurer};
+use crate::engine::{bridge::text::MeasuredFragment, layouter::types::TextStyle};
 
 /// Fallback text measurer.
 ///
@@ -15,44 +15,26 @@ impl TextMeasurer<TextStyle> for FallbackTextMeasurer {
     fn measure(
         &self,
         request: &TextMeasureRequest<TextStyle>,
-    ) -> Result<TextMetrics, TextMeasureError> {
+    ) -> Result<Vec<MeasuredFragment>, TextMeasureError> {
         let font_size = request.style.font_size.max(1.0);
 
         // Heuristic constants
         let char_width = font_size * 0.6;
         let line_height = font_size * 1.2;
 
-        let mut current_line_width = 0.0;
-        let mut max_line_width: f32 = 0.0;
-        let mut line_count = 1;
+        let fragments: Vec<MeasuredFragment> = request
+            .text
+            .split('\n')
+            .map(|line| {
+                let w = line.len() as f32 * char_width;
+                MeasuredFragment {
+                    text: line.to_string(),
+                    width: w,
+                    height: line_height,
+                }
+            })
+            .collect();
 
-        for ch in request.text.chars() {
-            if ch == '\n' {
-                max_line_width = max_line_width.max(current_line_width);
-                current_line_width = 0.0;
-                line_count += 1;
-                continue;
-            }
-
-            current_line_width += char_width;
-
-            if request.wrap
-                && let Some(max_width) = request.max_width
-                && current_line_width > max_width
-            {
-                max_line_width = max_line_width.max(current_line_width - char_width);
-                current_line_width = char_width;
-                line_count += 1;
-            }
-        }
-
-        max_line_width = max_line_width.max(current_line_width);
-
-        Ok(TextMetrics {
-            width: max_line_width,
-            height: line_height * line_count as f32,
-            baseline: font_size,
-            line_count,
-        })
+        Ok(fragments)
     }
 }

--- a/src/engine/bridge/text/mod.rs
+++ b/src/engine/bridge/text/mod.rs
@@ -40,31 +40,22 @@ pub struct TextMeasureRequest<S> {
 
     /// Opaque, resolved text attributes provided by the caller
     pub style: S,
-
-    /// Maximum line width (None = unconstrained)
-    pub max_width: Option<f32>,
-
-    /// Enable line wrapping
-    pub wrap: bool,
 }
 
 /* ============================
- * Measure Result
+ * Measured Result
  * ============================ */
 
+/// A measured text fragment produced by [`TextMeasurer::measure_fragments`].
+///
+/// Contains the original text segment along with its measured dimensions,
+/// so callers can both retrieve the split text and obtain fragment widths
+/// for inline layout.
 #[derive(Debug, Clone)]
-pub struct TextMetrics {
-    /// Logical width
+pub struct MeasuredFragment {
+    pub text: String,
     pub width: f32,
-
-    /// Logical height
     pub height: f32,
-
-    /// Baseline position from top
-    pub baseline: f32,
-
-    /// Number of layouted lines
-    pub line_count: usize,
 }
 
 /* ============================
@@ -109,7 +100,11 @@ impl std::error::Error for TextMeasureError {}
  * ============================ */
 
 pub trait TextMeasurer<S>: Send + Sync {
-    fn measure(&self, request: &TextMeasureRequest<S>) -> Result<TextMetrics, TextMeasureError>;
+    /// Measure a single block of text and return its metrics.
+    fn measure(
+        &self,
+        request: &TextMeasureRequest<S>,
+    ) -> Result<Vec<MeasuredFragment>, TextMeasureError>;
 }
 
 /* ============================

--- a/src/engine/layouter/builder.rs
+++ b/src/engine/layouter/builder.rs
@@ -354,7 +354,7 @@ pub fn build_layout_and_info(
                             kind: NodeKind::LineBreak,
                             children: vec![],
                         });
-                        break;
+                        continue;
                     }
 
                     let (child_layout, child_info) = build_layout_and_info(

--- a/src/engine/layouter/builder.rs
+++ b/src/engine/layouter/builder.rs
@@ -1,6 +1,6 @@
 //! Layout builder, which transforms a DOM tree into a UI layout.
 
-use crate::engine::bridge::text;
+use crate::engine::bridge::text::{self, MeasuredFragment};
 use crate::engine::css::{
     matcher::{ElementChain, ElementInfo},
     values::{CssValue, Unit},
@@ -339,13 +339,7 @@ pub fn build_layout_and_info(
                     };
 
                     for fragment in &measured {
-                        layout_children.push(
-                            ItemFragment::Fragment(Fragment {
-                                width: fragment.width,
-                                height: fragment.height,
-                            })
-                            .into(),
-                        );
+                        layout_children.push(generate_fragment_node(fragment).into());
                     }
 
                     info_children.push(InfoNode {
@@ -353,6 +347,15 @@ pub fn build_layout_and_info(
                         children: vec![],
                     });
                 } else {
+                    if child_dom.borrow().value.tag_name() == Some("br") {
+                        layout_children.push(ItemFragment::LineBreak.into());
+                        info_children.push(InfoNode {
+                            kind: NodeKind::LineBreak,
+                            children: vec![],
+                        });
+                        break;
+                    }
+
                     let (child_layout, child_info) = build_layout_and_info(
                         child_dom,
                         resolved_styles,
@@ -413,6 +416,17 @@ fn normalize_whitespace(text: &str) -> String {
     }
 
     result
+}
+
+fn generate_fragment_node(fragment: &MeasuredFragment) -> ItemFragment {
+    if fragment.text == "\n" {
+        ItemFragment::LineBreak
+    } else {
+        ItemFragment::Fragment(Fragment {
+            width: fragment.width,
+            height: fragment.height,
+        })
+    }
 }
 
 fn collect_candidates(

--- a/src/engine/layouter/builder.rs
+++ b/src/engine/layouter/builder.rs
@@ -180,12 +180,41 @@ pub fn build_layout_and_info(
     let (mut kind, inline_fragments_opt) = if let HtmlNodeType::Text(t) = &html_node {
         let t = normalize_whitespace(t);
 
-        let mut kind = NodeKind::Text {
-            texts: split_fragments(&t),
+        let _t = std::time::Instant::now();
+        let measured = measurer
+            .measure(&text::TextMeasureRequest {
+                text: t.clone(),
+                style: text_style,
+            })
+            .expect("text measure failed");
+        let preview = if t.len() > 40 {
+            let cut = t.floor_char_boundary(40);
+            format!("{}...", &t[..cut])
+        } else {
+            t.clone()
+        };
+        log::info!(
+            target: "Layouter",
+            "measure inline: text={:?} len={} took={:?}",
+            preview,
+            t.len(),
+            _t.elapsed(),
+        );
+
+        let kind = NodeKind::Text {
+            texts: measured.iter().map(|f| f.text.clone()).collect(),
             style: text_style,
         };
 
-        let inline_fragments = build_fragments(&mut kind, measurer);
+        let inline_fragments: Vec<ItemFragment> = measured
+            .into_iter()
+            .map(|f| {
+                ItemFragment::Fragment(Fragment {
+                    width: f.width,
+                    height: f.height,
+                })
+            })
+            .collect();
 
         (kind, Some(inline_fragments))
     } else if let Some(name) = html_node.tag_name()
@@ -283,14 +312,40 @@ pub fn build_layout_and_info(
 
                 if let HtmlNodeType::Text(t) = &child_node {
                     let t = normalize_whitespace(t);
-                    let mut text_kind = NodeKind::Text {
-                        texts: split_fragments(&t),
+                    let _t = std::time::Instant::now();
+                    let measured = measurer
+                        .measure(&text::TextMeasureRequest {
+                            text: t.clone(),
+                            style: text_style,
+                        })
+                        .expect("text measure failed");
+                    let preview = if t.len() > 40 {
+                        let cut = t.floor_char_boundary(40);
+                        format!("{}...", &t[..cut])
+                    } else {
+                        t.clone()
+                    };
+                    log::info!(
+                        target: "Layouter",
+                        "measure child: text={:?} len={} took={:?}",
+                        preview,
+                        t.len(),
+                        _t.elapsed(),
+                    );
+
+                    let text_kind = NodeKind::Text {
+                        texts: measured.iter().map(|f| f.text.clone()).collect(),
                         style: text_style,
                     };
-                    let fragments = build_fragments(&mut text_kind, measurer);
 
-                    for fragment in fragments {
-                        layout_children.push(fragment.into());
+                    for fragment in &measured {
+                        layout_children.push(
+                            ItemFragment::Fragment(Fragment {
+                                width: fragment.width,
+                                height: fragment.height,
+                            })
+                            .into(),
+                        );
                     }
 
                     info_children.push(InfoNode {
@@ -339,57 +394,6 @@ pub fn build_layout_and_info(
     };
 
     (layout, info)
-}
-
-/// Splits text into text fragments for measurement. Each fragment is a word or a space.
-fn split_fragments(text: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut buf = String::new();
-
-    for c in text.chars() {
-        buf.push(c);
-
-        if c.is_whitespace() || c == '-' || !c.is_ascii() {
-            out.push(buf.clone());
-            buf.clear();
-        }
-    }
-
-    if !buf.is_empty() {
-        out.push(buf);
-    }
-
-    out
-}
-
-fn build_fragments(
-    kind: &mut NodeKind,
-    measurer: &dyn text::TextMeasurer<TextStyle>,
-) -> Vec<ItemFragment> {
-    let NodeKind::Text { texts, style } = kind else {
-        return vec![];
-    };
-
-    let mut inline_fragments = Vec::with_capacity(texts.len());
-
-    for text in texts {
-        let req = text::TextMeasureRequest {
-            text: text.clone(),
-            style: *style,
-            max_width: None,
-            wrap: false,
-        };
-
-        let (width, height) = measurer
-            .measure(&req)
-            .map_or((800.0, style.font_size * 1.2), |m| (m.width, m.height));
-
-        let fragment = ItemFragment::Fragment(Fragment { width, height });
-
-        inline_fragments.push(fragment);
-    }
-
-    inline_fragments
 }
 
 fn normalize_whitespace(text: &str) -> String {

--- a/src/engine/layouter/builder.rs
+++ b/src/engine/layouter/builder.rs
@@ -1,6 +1,6 @@
 //! Layout builder, which transforms a DOM tree into a UI layout.
 
-use crate::engine::bridge::text::{self, MeasuredFragment};
+use crate::engine::bridge::text::{self, FallbackTextMeasurer, MeasuredFragment, TextMeasurer};
 use crate::engine::css::{
     matcher::{ElementChain, ElementInfo},
     values::{CssValue, Unit},
@@ -313,12 +313,13 @@ pub fn build_layout_and_info(
                 if let HtmlNodeType::Text(t) = &child_node {
                     let t = normalize_whitespace(t);
                     let _t = std::time::Instant::now();
-                    let measured = measurer
-                        .measure(&text::TextMeasureRequest {
-                            text: t.clone(),
-                            style: text_style,
-                        })
-                        .expect("text measure failed");
+                    let request = &text::TextMeasureRequest {
+                        text: t.clone(),
+                        style: text_style,
+                    };
+                    let measured = measurer.measure(request).unwrap_or_else(|_|
+                            // FallbackTextMeasurer won't return any errors.
+                            FallbackTextMeasurer.measure(request).unwrap());
                     let preview = if t.len() > 40 {
                         let cut = t.floor_char_boundary(40);
                         format!("{}...", &t[..cut])

--- a/src/engine/layouter/types.rs
+++ b/src/engine/layouter/types.rs
@@ -37,6 +37,7 @@ pub enum NodeKind {
         texts: Vec<String>,
         style: TextStyle,
     },
+    LineBreak,
 }
 
 // =========================

--- a/src/engine/renderer_model/draw_command.rs
+++ b/src/engine/renderer_model/draw_command.rs
@@ -61,7 +61,7 @@ pub fn generate_draw_commands(
     let mut box_states: Vec<BoxPushState> = Vec::new();
 
     match &info.kind {
-        NodeKind::Text { .. } => unreachable!(),
+        NodeKind::Text { .. } | NodeKind::LineBreak => unreachable!(),
 
         NodeKind::Container {
             scroll_offset_x,
@@ -221,7 +221,10 @@ pub fn generate_draw_commands(
                     }
                 }
             }
-            _ => {
+            NodeKind::LineBreak => {
+                layout_iter.next();
+            }
+            NodeKind::Container { .. } => {
                 if let Some(LayoutChild::Node(node)) = layout_iter.next() {
                     generate_draw_commands(cmd_buf, node, child_info);
                 }

--- a/src/platform/audio/mod.rs
+++ b/src/platform/audio/mod.rs
@@ -112,18 +112,12 @@ impl SoundManager {
         let (samples, channels, sample_rate) = decode(data)?;
         // replace buffer
         {
-            let mut buf = match self.samples.lock() {
-                Ok(x) => x,
-                Err(_) => todo!(),
-            };
+            let mut buf = self.samples.lock().unwrap_or_else(|e| e.into_inner());
             *buf = samples;
         }
         // reset position
         {
-            let mut pos = match self.play_pos.lock() {
-                Ok(x) => x,
-                Err(_) => todo!(),
-            };
+            let mut pos = self.play_pos.lock().unwrap_or_else(|e| e.into_inner());
             *pos = 0;
         }
         self.src_channels = channels;

--- a/src/platform/renderer/gpu.rs
+++ b/src/platform/renderer/gpu.rs
@@ -7,7 +7,7 @@ use std::{env, fmt::Debug};
 use wgpu::util::DeviceExt;
 use winit::window::Window;
 
-use super::glyph::text::{TextRenderer, TextSection};
+use super::text::text::{TextRenderer, TextSection};
 
 /// GPU描画コンテキスト
 pub struct GpuRenderer {
@@ -453,13 +453,13 @@ impl GpuRenderer {
                     let section = if let Some(tr) = &mut self.text_renderer {
                         let mut render_text_style = *style;
                         render_text_style.font_size = *font_size * sf;
-                        let buffer = tr.create_buffer_for_text(text, render_text_style);
+                        let layout = tr.create_buffer_for_text(text, render_text_style);
 
                         TextSection {
                             screen_position: ((*x + tdx) * sf, (*y + tdy) * sf),
                             clip_origin: (clip.x * sf, clip.y * sf),
                             bounds: (tw * sf, th * sf),
-                            buffer,
+                            layout,
                         }
                     } else {
                         // No text renderer available; skip

--- a/src/platform/renderer/mod.rs
+++ b/src/platform/renderer/mod.rs
@@ -1,6 +1,6 @@
 //! Renderer module. Text, image, and GPU rendering.
 
-mod glyph;
+mod text;
 pub mod gpu;
 mod image;
 pub(crate) mod scroll_bar;

--- a/src/platform/renderer/shader/text.wgsl
+++ b/src/platform/renderer/shader/text.wgsl
@@ -1,0 +1,33 @@
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) tex_coord: vec2<f32>,
+    @location(2) layer: f32,
+    @location(3) color: vec4<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) layer: f32,
+    @location(2) color: vec4<f32>,
+};
+
+@group(0) @binding(0) var atlas: texture_2d_array<f32>;
+@group(0) @binding(1) var atlas_sampler: sampler;
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+    output.clip_pos = vec4<f32>(input.position, 0.0, 1.0);
+    output.tex_coord = input.tex_coord;
+    output.layer = input.layer;
+    output.color = input.color;
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let layer = i32(input.layer);
+    let alpha = textureSample(atlas, atlas_sampler, input.tex_coord, layer).r;
+    return vec4<f32>(input.color.rgb, input.color.a * alpha);
+}

--- a/src/platform/renderer/text/atlas.rs
+++ b/src/platform/renderer/text/atlas.rs
@@ -1,0 +1,302 @@
+use std::collections::HashMap;
+
+use etagere::{BucketedAtlasAllocator, size2};
+use orinium_text::{FontKey, fontdb};
+
+/// (fontdb ID, glyph_id, font_size_bits)
+type GlyphKey = (fontdb::ID, u32, u32);
+
+/// (layer_index, alloc_id, rectangle_packed, actual_width, actual_height)
+type GlyphCacheValue = (u32, etagere::AllocId, etagere::Rectangle, u32, u32);
+
+/// (layer_index, rectangle, alpha_mask, actual_width, actual_height)
+type PendingUpload = (u32, etagere::Rectangle, Vec<u8>, u32, u32);
+
+/// Normalized UV rect: (layer, u, v, width, height)
+pub type GlyphUVRect = (u32, f32, f32, f32, f32);
+
+/// A packed glyph atlas managed as a wgpu 2D array texture.
+///
+/// Each layer holds a single row of shelf-packed glyph bitmaps.
+/// When a layer runs out of space, a new layer is added (up to
+/// MAX_LAYERS).  When all layers are full, the atlas is grown by
+/// doubling the texture size and re-packing every existing glyph.
+pub struct GlyphAtlas {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    size: u32,
+    layers: u32,
+    allocators: Vec<BucketedAtlasAllocator>,
+    glyph_map: HashMap<GlyphKey, GlyphCacheValue>,
+    pending_uploads: Vec<PendingUpload>,
+}
+
+const MAX_LAYERS: u32 = 16;
+const INITIAL_SIZE: u32 = 1024;
+
+impl GlyphAtlas {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let size = INITIAL_SIZE;
+        let layers = 1;
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Glyph Atlas"),
+            size: wgpu::Extent3d {
+                width: size,
+                height: size,
+                depth_or_array_layers: layers,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor {
+            label: Some("Glyph Atlas View"),
+            dimension: Some(wgpu::TextureViewDimension::D2Array),
+            ..Default::default()
+        });
+        let allocator = BucketedAtlasAllocator::new(size2(size as i32, size as i32));
+
+        Self {
+            texture,
+            view,
+            size,
+            layers,
+            allocators: vec![allocator],
+            glyph_map: HashMap::new(),
+            pending_uploads: Vec::new(),
+        }
+    }
+
+    pub fn texture_view(&self) -> &wgpu::TextureView {
+        &self.view
+    }
+
+    /// Returns cached (layer, u, v, w, h) if the glyph is already in the atlas.
+    pub fn lookup(&self, font_key: FontKey, glyph_id: u32, font_size: f32) -> Option<GlyphUVRect> {
+        let key = (font_key.0, glyph_id, font_size.to_bits());
+        let (layer, _alloc_id, rect, aw, ah) = self.glyph_map.get(&key)?;
+        let (u, v) = (
+            rect.min.x as f32 / self.size as f32,
+            rect.min.y as f32 / self.size as f32,
+        );
+        let (w, h) = (*aw as f32 / self.size as f32, *ah as f32 / self.size as f32);
+        Some((*layer, u, v, w, h))
+    }
+
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        font_key: FontKey,
+        glyph_id: u32,
+        font_size: f32,
+        alpha_mask: &[u8],
+        mask_width: u32,
+        mask_height: u32,
+    ) -> GlyphUVRect {
+        if mask_width == 0 || mask_height == 0 {
+            return (0, 0.0, 0.0, 0.0, 0.0);
+        }
+
+        let key = (font_key.0, glyph_id, font_size.to_bits());
+
+        if let Some((layer, _alloc_id, rect, aw, ah)) = self.glyph_map.get(&key) {
+            let (u, v) = (
+                rect.min.x as f32 / self.size as f32,
+                rect.min.y as f32 / self.size as f32,
+            );
+            let (w, h) = (*aw as f32 / self.size as f32, *ah as f32 / self.size as f32);
+            return (*layer, u, v, w, h);
+        }
+
+        let item_w = mask_width.max(1) as i32;
+        let item_h = mask_height.max(1) as i32;
+
+        for (layer_idx, alloc) in self.allocators.iter_mut().enumerate() {
+            if let Some(allocation) = alloc.allocate(size2(item_w, item_h)) {
+                let rect = allocation.rectangle;
+                let alloc_id = allocation.id;
+                self.glyph_map.insert(
+                    key,
+                    (layer_idx as u32, alloc_id, rect, mask_width, mask_height),
+                );
+                self.pending_uploads.push((
+                    layer_idx as u32,
+                    rect,
+                    alpha_mask.to_vec(),
+                    mask_width,
+                    mask_height,
+                ));
+                let (u, v) = (
+                    rect.min.x as f32 / self.size as f32,
+                    rect.min.y as f32 / self.size as f32,
+                );
+                let (w, h) = (
+                    mask_width as f32 / self.size as f32,
+                    mask_height as f32 / self.size as f32,
+                );
+                return (layer_idx as u32, u, v, w, h);
+            }
+        }
+
+        if self.layers < MAX_LAYERS {
+            let new_layer = self.layers;
+            self.layers += 1;
+            let mut alloc = BucketedAtlasAllocator::new(size2(self.size as i32, self.size as i32));
+            if let Some(allocation) = alloc.allocate(size2(item_w, item_h)) {
+                let rect = allocation.rectangle;
+                let alloc_id = allocation.id;
+                self.allocators.push(alloc);
+                self.glyph_map
+                    .insert(key, (new_layer, alloc_id, rect, mask_width, mask_height));
+                self.pending_uploads.push((
+                    new_layer,
+                    rect,
+                    alpha_mask.to_vec(),
+                    mask_width,
+                    mask_height,
+                ));
+
+                let texture = device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("Glyph Atlas"),
+                    size: wgpu::Extent3d {
+                        width: self.size,
+                        height: self.size,
+                        depth_or_array_layers: self.layers,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::R8Unorm,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                    view_formats: &[],
+                });
+                let mut encoder =
+                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+                for old_layer in 0..new_layer {
+                    encoder.copy_texture_to_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &self.texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d {
+                                x: 0,
+                                y: 0,
+                                z: old_layer,
+                            },
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d {
+                                x: 0,
+                                y: 0,
+                                z: old_layer,
+                            },
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::Extent3d {
+                            width: self.size,
+                            height: self.size,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                queue.submit(std::iter::once(encoder.finish()));
+
+                self.texture = texture;
+                self.view = self.texture.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some("Glyph Atlas View"),
+                    dimension: Some(wgpu::TextureViewDimension::D2Array),
+                    ..Default::default()
+                });
+
+                self.flush_uploads(queue);
+
+                let (u, v) = (
+                    rect.min.x as f32 / self.size as f32,
+                    rect.min.y as f32 / self.size as f32,
+                );
+                let (w, h) = (
+                    mask_width as f32 / self.size as f32,
+                    mask_height as f32 / self.size as f32,
+                );
+                return (new_layer, u, v, w, h);
+            }
+        }
+
+        log::warn!(target:"GlyphAtlas", "glyph atlas full ({} layers used)", self.layers);
+        (0, 0.0, 0.0, 0.0, 0.0)
+    }
+
+    pub fn flush_uploads(&mut self, queue: &wgpu::Queue) {
+        for (layer, rect, data, actual_w, actual_h) in self.pending_uploads.drain(..) {
+            let width = actual_w.max(1);
+            let height = actual_h.max(1);
+
+            let bytes_per_pixel = 1u32;
+            let stride = width * bytes_per_pixel;
+            let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+            let padded_stride = ((stride + align - 1) / align) * align;
+
+            let layout = wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_stride),
+                rows_per_image: Some(height),
+            };
+
+            if padded_stride == stride {
+                queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &self.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: rect.min.x as u32,
+                            y: rect.min.y as u32,
+                            z: layer,
+                        },
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &data,
+                    layout,
+                    wgpu::Extent3d {
+                        width,
+                        height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            } else {
+                let mut padded = Vec::with_capacity((padded_stride * height) as usize);
+                for row in data.chunks(stride as usize) {
+                    padded.extend_from_slice(row);
+                    let pad = (padded_stride - stride) as usize;
+                    if pad > 0 {
+                        padded.extend(std::iter::repeat(0u8).take(pad));
+                    }
+                }
+                queue.write_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &self.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: rect.min.x as u32,
+                            y: rect.min.y as u32,
+                            z: layer,
+                        },
+                        aspect: wgpu::TextureAspect::All,
+                    },
+                    &padded,
+                    layout,
+                    wgpu::Extent3d {
+                        width,
+                        height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
+        }
+    }
+}

--- a/src/platform/renderer/text/mod.rs
+++ b/src/platform/renderer/text/mod.rs
@@ -1,0 +1,2 @@
+pub mod atlas;
+pub mod text;

--- a/src/platform/renderer/text/text.rs
+++ b/src/platform/renderer/text/text.rs
@@ -1,0 +1,464 @@
+use bytemuck::{Pod, Zeroable};
+use orinium_text::{
+    Color as OriColor, FontStyle as OriFontStyle, FontSystem, FontWeight as OriFontWeight,
+    TextLayouter, TextStyle as OriTextStyle, fontdb,
+};
+use wgpu::util::DeviceExt;
+
+use super::atlas::GlyphAtlas;
+use crate::engine::layouter::types::{FontStyle, LineHeight, TextStyle};
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct GlyphVertex {
+    position: [f32; 2],
+    tex_coord: [f32; 2],
+    layer: f32,
+    color: [f32; 4],
+}
+
+/// テキストセクション位置・クリップ・描画範囲をまとめた構造体
+pub struct TextSection {
+    pub screen_position: (f32, f32),
+    pub clip_origin: (f32, f32),
+    pub bounds: (f32, f32),
+    pub layout: orinium_text::TextLayout,
+}
+
+/// テキストレンダラー (orinium_text + wgpu グリフアトラス)
+pub struct TextRenderer {
+    font_sys: FontSystem,
+    layouter: TextLayouter,
+    atlas: GlyphAtlas,
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    bind_group: Option<wgpu::BindGroup>,
+    sampler: wgpu::Sampler,
+    vertex_buffer: Option<wgpu::Buffer>,
+    index_buffer: Option<wgpu::Buffer>,
+    num_indices: u32,
+    vertices: Vec<GlyphVertex>,
+    indices: Vec<u32>,
+    screen_width: f32,
+    screen_height: f32,
+}
+
+impl TextRenderer {
+    /// システムフォントから初期化する
+    pub fn new_from_device(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+    ) -> anyhow::Result<Self> {
+        if let Ok(p) = std::env::var("ORINIUM_FONT")
+            && let Ok(bytes) = std::fs::read(&p)
+        {
+            return Self::new_from_bytes(device, queue, format, bytes);
+        }
+
+        for p in crate::platform::font::system_font_candidates()? {
+            if let Ok(bytes) = std::fs::read(p) {
+                return Self::new_from_bytes(device, queue, format, bytes);
+            }
+        }
+
+        anyhow::bail!("no system font found");
+    }
+
+    /// FontSystem を受け取って生成する
+    pub fn new_with_fontsys(
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+        font_sys: FontSystem,
+    ) -> anyhow::Result<Self> {
+        let atlas = GlyphAtlas::new(device);
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Glyph Atlas Sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Text Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Text Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shader/text.wgsl").into()),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Text Pipeline Layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Text Render Pipeline"),
+            layout: Some(&pipeline_layout),
+            cache: None,
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: size_of::<GlyphVertex>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x2,
+                            offset: 0,
+                            shader_location: 0,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x2,
+                            offset: size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                            shader_location: 1,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32,
+                            offset: (size_of::<[f32; 2]>() * 2) as wgpu::BufferAddress,
+                            shader_location: 2,
+                        },
+                        wgpu::VertexAttribute {
+                            format: wgpu::VertexFormat::Float32x4,
+                            offset: (size_of::<[f32; 2]>() * 2 + size_of::<f32>())
+                                as wgpu::BufferAddress,
+                            shader_location: 3,
+                        },
+                    ],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+        });
+
+        let layouter = TextLayouter::new();
+
+        Ok(Self {
+            font_sys,
+            layouter,
+            atlas,
+            pipeline,
+            bind_group_layout,
+            bind_group: None,
+            sampler,
+            vertex_buffer: None,
+            index_buffer: None,
+            num_indices: 0,
+            vertices: Vec::new(),
+            indices: Vec::new(),
+            screen_width: 800.0,
+            screen_height: 600.0,
+        })
+    }
+
+    /// フォントバイト列から生成する
+    pub fn new_from_bytes(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        format: wgpu::TextureFormat,
+        font_bytes: Vec<u8>,
+    ) -> anyhow::Result<Self> {
+        let font_sys = FontSystem::new_with_fonts(vec![font_bytes]);
+        Self::new_with_fontsys(device, queue, format, font_sys)
+    }
+
+    /// Create an orinium_text `TextLayout` for the given text using the internal `FontSystem`.
+    pub fn create_buffer_for_text(
+        &mut self,
+        text: &str,
+        style: TextStyle,
+    ) -> orinium_text::TextLayout {
+        let font_size = style.font_size;
+        let line_height_ratio = match style.line_height {
+            LineHeight::Normal => 1.2,
+            LineHeight::Number(n) => n,
+            LineHeight::Px(px) => px / font_size,
+        };
+
+        let ori_style = OriTextStyle {
+            font_size,
+            color: OriColor(style.color.0, style.color.1, style.color.2, style.color.3),
+            font_weight: OriFontWeight(style.font_weight.0),
+            font_style: match style.font_style {
+                FontStyle::Normal => OriFontStyle::Normal,
+                FontStyle::Italic => OriFontStyle::Italic,
+                FontStyle::Oblique => OriFontStyle::Oblique,
+            },
+            line_height: line_height_ratio,
+            bidi_mode: orinium_text::BidiMode::Auto,
+            font_families: vec![fontdb::Family::SansSerif],
+            exact_fonts: self.font_sys.font_keys(),
+        };
+
+        let shaped = self
+            .layouter
+            .shape_text(&mut self.font_sys, text, &ori_style);
+
+        let line_ranges: Vec<(usize, usize)> = text
+            .split('\n')
+            .scan(0usize, |offset, line| {
+                let start = *offset;
+                *offset += line.len() + 1;
+                let end = start + line.len();
+                Some((start, end))
+            })
+            .collect();
+
+        self.layouter
+            .layout_lines(&mut self.font_sys, &shaped, &line_ranges, &ori_style)
+    }
+
+    pub fn resize_view(&mut self, width: f32, height: f32, _queue: &wgpu::Queue) {
+        self.screen_width = width;
+        self.screen_height = height;
+    }
+
+    /// 指定されたセクション群をギリフォン用の TextArea に変換して Atlas に転送する
+    pub fn queue(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        sections: &[TextSection],
+    ) -> anyhow::Result<()> {
+        self.vertices.clear();
+        self.indices.clear();
+
+        let ndc_x = |sx: f32| (sx / self.screen_width) * 2.0 - 1.0;
+        let ndc_y = |sy: f32| -((sy / self.screen_height) * 2.0 - 1.0);
+
+        for section in sections {
+            let layout = &section.layout;
+
+            let base_x = section.screen_position.0;
+            let base_y = section.screen_position.1;
+
+            let clip_l = section.clip_origin.0;
+            let clip_t = section.clip_origin.1;
+            let clip_r = section.clip_origin.0 + section.bounds.0;
+            let clip_b = section.clip_origin.1 + section.bounds.1;
+
+            for line in &layout.lines {
+                for glyph in &line.glyphs {
+                    let Some(font_key) = glyph.font_key else {
+                        continue;
+                    };
+
+                    let gx = base_x + glyph.x;
+                    let gy = base_y + glyph.y;
+
+                    // Cull against clip rect
+                    if gx + glyph.width <= clip_l
+                        || gx >= clip_r
+                        || gy + glyph.height <= clip_t
+                        || gy >= clip_b
+                    {
+                        continue;
+                    }
+
+                    let (layer, u, v, uw, uh) =
+                        match self.atlas.lookup(font_key, glyph.glyph_id, glyph.font_size) {
+                            Some(uv) => uv,
+                            None => {
+                                if let Some((metrics, alpha_mask)) =
+                                    self.font_sys.get_or_rasterize_with_bitmap(
+                                        font_key,
+                                        glyph.glyph_id,
+                                        glyph.font_size,
+                                    )
+                                {
+                                    if metrics.width == 0 || metrics.height == 0 {
+                                        continue;
+                                    }
+                                    let mask_w = metrics.width;
+                                    let mask_h = metrics.height;
+                                    self.atlas.upload(
+                                        device,
+                                        queue,
+                                        font_key,
+                                        glyph.glyph_id,
+                                        glyph.font_size,
+                                        &alpha_mask,
+                                        mask_w,
+                                        mask_h,
+                                    )
+                                } else {
+                                    continue;
+                                }
+                            }
+                        };
+
+                    // Convert screen coords to NDC
+                    let quad_x1 = ndc_x(gx);
+                    let quad_y1 = ndc_y(gy);
+                    let quad_x2 = ndc_x(gx + glyph.width);
+                    let quad_y2 = ndc_y(gy + glyph.height);
+
+                    // NDC Y is flipped: upper-left becomes min, lower-right becomes max
+                    let (qy1, qy2) = if quad_y1 < quad_y2 {
+                        (quad_y1, quad_y2)
+                    } else {
+                        (quad_y2, quad_y1)
+                    };
+
+                    let idx = self.vertices.len() as u32;
+                    let layer_f = layer as f32;
+
+                    let color_arr = crate::engine::layouter::types::Color(
+                        glyph.color.0,
+                        glyph.color.1,
+                        glyph.color.2,
+                        glyph.color.3,
+                    )
+                    .to_linear_f32_array();
+
+                    self.vertices.extend_from_slice(&[
+                        GlyphVertex {
+                            position: [quad_x1, qy1],
+                            tex_coord: [u, v + uh],
+                            layer: layer_f,
+                            color: color_arr,
+                        },
+                        GlyphVertex {
+                            position: [quad_x2, qy1],
+                            tex_coord: [u + uw, v + uh],
+                            layer: layer_f,
+                            color: color_arr,
+                        },
+                        GlyphVertex {
+                            position: [quad_x2, qy2],
+                            tex_coord: [u + uw, v],
+                            layer: layer_f,
+                            color: color_arr,
+                        },
+                        GlyphVertex {
+                            position: [quad_x1, qy2],
+                            tex_coord: [u, v],
+                            layer: layer_f,
+                            color: color_arr,
+                        },
+                    ]);
+
+                    self.indices
+                        .extend_from_slice(&[idx, idx + 1, idx + 2, idx, idx + 2, idx + 3]);
+                }
+            }
+        }
+
+        self.atlas.flush_uploads(queue);
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Text Bind Group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(self.atlas.texture_view()),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+        });
+        self.bind_group = Some(bind_group);
+
+        self.num_indices = self.indices.len() as u32;
+        if !self.vertices.is_empty() {
+            self.vertex_buffer = Some(device.create_buffer_init(
+                &wgpu::util::BufferInitDescriptor {
+                    label: Some("Text Vertex Buffer"),
+                    contents: bytemuck::cast_slice(&self.vertices),
+                    usage: wgpu::BufferUsages::VERTEX,
+                },
+            ));
+        } else {
+            self.vertex_buffer = None;
+        }
+        if !self.indices.is_empty() {
+            self.index_buffer = Some(device.create_buffer_init(
+                &wgpu::util::BufferInitDescriptor {
+                    label: Some("Text Index Buffer"),
+                    contents: bytemuck::cast_slice(&self.indices),
+                    usage: wgpu::BufferUsages::INDEX,
+                },
+            ));
+        } else {
+            self.index_buffer = None;
+        }
+
+        Ok(())
+    }
+
+    /// テキストをレンダリングする
+    pub fn draw<'a>(&mut self, rpass: &mut wgpu::RenderPass<'a>) {
+        let Some(ref bind_group) = self.bind_group else {
+            return;
+        };
+        let Some(ref vertex_buffer) = self.vertex_buffer else {
+            return;
+        };
+        let Some(ref index_buffer) = self.index_buffer else {
+            return;
+        };
+        if self.num_indices == 0 {
+            return;
+        }
+
+        rpass.set_pipeline(&self.pipeline);
+        rpass.set_bind_group(0, bind_group, &[]);
+        rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        rpass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+        rpass.draw_indexed(0..self.num_indices, 0, 0..1);
+    }
+}

--- a/src/platform/renderer/text_measurer.rs
+++ b/src/platform/renderer/text_measurer.rs
@@ -1,30 +1,29 @@
 //! Text measurement interface and implementations.
 
 use crate::engine::bridge::text::{
-    TextMeasureError, TextMeasureRequest, TextMeasurer, TextMetrics,
+    MeasuredFragment, TextMeasureError, TextMeasureRequest, TextMeasurer,
 };
-use crate::engine::layouter::types::TextStyle;
+use crate::engine::layouter::types::{FontStyle, LineHeight, TextStyle as EngineTextStyle};
 
 use std::env;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
-use glyphon::{Attrs, Buffer, Color as GlyphColor, FontSystem, Metrics, Shaping, Style, Weight};
+use orinium_text::TextStyle as OriTextStyle;
+use orinium_text::{
+    BidiMode, Color as OriColor, FontKey, FontStyle as OriFontStyle, FontSystem,
+    FontWeight as OriFontWeight, TextLayouter, fontdb,
+};
 
-/// Platform-backed text measurer using glyphon / cosmic-text.
+/// Platform-backed text measurer using orinium_text.
 ///
 /// This measurer performs real text shaping and line layout,
 /// and is intended for production use.
 pub struct PlatformTextMeasurer {
-    /// Font system used for shaping and metrics
     font_sys: Mutex<FontSystem>,
+    font_keys: Vec<FontKey>,
 }
 
 impl PlatformTextMeasurer {
-    /// Initialize using system fonts.
-    ///
-    /// TODO:
-    /// - Share font system with PlatformTextRenderer
-    /// - Support font family / fallback selection
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
         let mut maybe_bytes: Option<Vec<u8>> = None;
 
@@ -43,96 +42,126 @@ impl PlatformTextMeasurer {
             }
         }
 
-        if let Some(bytes) = maybe_bytes {
-            let font_source = Arc::new(bytes);
-            let font = glyphon::fontdb::Source::Binary(font_source);
-            let font_sys = FontSystem::new_with_fonts(vec![font]);
-
-            return Ok(Self {
-                font_sys: Mutex::new(font_sys),
-            });
-        }
-
-        Err("no system font found".into())
-    }
-
-    /// Initialize from raw font bytes.
-    pub fn from_bytes(_id: &str, bytes: Vec<u8>) -> Result<Self, Box<dyn std::error::Error>> {
-        let font_source = Arc::new(bytes);
-        let font = glyphon::fontdb::Source::Binary(font_source);
-        let font_sys = FontSystem::new_with_fonts(vec![font]);
+        let (font_sys, font_keys) = match maybe_bytes {
+            Some(bytes) => {
+                let mut sys = FontSystem::new();
+                let keys = sys.load_font_data(bytes);
+                (sys, keys)
+            }
+            None => return Err("no system font found".into()),
+        };
 
         Ok(Self {
             font_sys: Mutex::new(font_sys),
+            font_keys,
+        })
+    }
+
+    pub fn from_bytes(_id: &str, bytes: Vec<u8>) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut font_sys = FontSystem::new();
+        let font_keys = font_sys.load_font_data(bytes);
+        Ok(Self {
+            font_sys: Mutex::new(font_sys),
+            font_keys,
         })
     }
 }
 
-impl TextMeasurer<TextStyle> for PlatformTextMeasurer {
-    /// Measure text using real shaping and line layout.
-    ///
-    /// Notes:
-    /// - Baseline is currently approximated
-    /// - Decorations and alignment are handled at render time
+impl TextMeasurer<EngineTextStyle> for PlatformTextMeasurer {
     fn measure(
         &self,
-        req: &TextMeasureRequest<TextStyle>,
-    ) -> Result<TextMetrics, TextMeasureError> {
+        req: &TextMeasureRequest<EngineTextStyle>,
+    ) -> Result<Vec<MeasuredFragment>, TextMeasureError> {
+        let _t0 = std::time::Instant::now();
+
         let font_size = req.style.font_size.max(1.0);
 
         let mut fs = self
             .font_sys
             .lock()
             .map_err(|e| TextMeasureError::Internal(format!("font_sys lock poisoned: {}", e)))?;
+        let t_lock = _t0.elapsed();
 
-        // glyphon metrics: font size + line height
-        let metrics = Metrics::relative(font_size, 1.2);
-        let mut buffer = Buffer::new(&mut fs, metrics);
+        let line_height_ratio = match req.style.line_height {
+            LineHeight::Normal => 1.2,
+            LineHeight::Number(n) => n,
+            LineHeight::Px(px) => px / font_size,
+        };
 
-        // Attributes used only for shaping / layout
-        let attrs = Attrs::new()
-            .metrics(metrics)
-            .color(GlyphColor::rgba(0, 0, 0, 255))
-            .weight(Weight(req.style.font_weight.0))
-            .style(Style::from(req.style.font_style));
+        let ori_style = OriTextStyle {
+            font_size,
+            color: OriColor(
+                req.style.color.0,
+                req.style.color.1,
+                req.style.color.2,
+                req.style.color.3,
+            ),
+            font_weight: OriFontWeight(req.style.font_weight.0),
+            font_style: match req.style.font_style {
+                FontStyle::Normal => OriFontStyle::Normal,
+                FontStyle::Italic => OriFontStyle::Italic,
+                FontStyle::Oblique => OriFontStyle::Oblique,
+            },
+            line_height: line_height_ratio,
+            bidi_mode: BidiMode::Auto,
+            font_families: vec![fontdb::Family::SansSerif],
+            exact_fonts: self.font_keys.clone(),
+        };
 
-        buffer.set_text(&mut fs, &req.text, &attrs, Shaping::Advanced, None);
+        let mut layouter = TextLayouter::new();
 
-        let mut max_width: f32 = 0.0;
-        let mut line_count: usize = 0;
+        let t_shape = std::time::Instant::now();
+        let shaped = layouter.shape_text(&mut *fs, &req.text, &ori_style);
+        let t_shape = t_shape.elapsed();
 
-        // Iterate over shaped lines
-        for para_i in 0..buffer.lines.len() {
-            if let Some(layout_lines) = buffer.line_layout(&mut fs, para_i) {
-                for line in layout_lines {
-                    max_width = max_width.max(line.w);
-                    line_count += 1;
+        let line_ranges: Vec<(usize, usize)> = req
+            .text
+            .split('\n')
+            .scan(0usize, |offset, line| {
+                let start = *offset;
+                *offset += line.len() + 1;
+                let end = start + line.len();
+                Some((start, end))
+            })
+            .collect();
+
+        let t_layout = std::time::Instant::now();
+        let layout = layouter.layout_lines(&mut *fs, &shaped, &line_ranges, &ori_style);
+        let t_layout = t_layout.elapsed();
+
+        let fragments: Vec<MeasuredFragment> = layout
+            .lines
+            .iter()
+            .enumerate()
+            .map(|(i, line)| {
+                let line_text = line_ranges[i];
+                MeasuredFragment {
+                    text: req.text[line_text.0..line_text.1].to_string(),
+                    width: line.width,
+                    height: line.height,
                 }
-            }
-        }
+            })
+            .collect();
 
-        if line_count == 0 {
-            // Empty text
-            return Ok(TextMetrics {
-                width: 0.0,
-                height: metrics.line_height,
-                baseline: font_size * 0.8,
-                line_count: 1,
-            });
-        }
-
-        // Apply wrapping constraint
-        if let Some(max_width_limit) = req.max_width {
-            max_width = max_width.min(max_width_limit);
-        }
-
-        let height = metrics.line_height * line_count as f32;
-
-        Ok(TextMetrics {
-            width: max_width,
-            height,
-            baseline: font_size * 0.8, // TODO: precise baseline from font metrics
-            line_count,
-        })
+        let total = _t0.elapsed();
+        let preview = if req.text.len() > 40 {
+            let cut = req.text.floor_char_boundary(40);
+            format!("{}...", &req.text[..cut])
+        } else {
+            req.text.clone()
+        };
+        log::info!(
+            target: "TextMeasurer",
+            "measure: text={:?} len={} font_size={}  lock={:?}  shape={:?}  layout={:?}  total={:?}  fragments={}",
+            preview,
+            req.text.len(),
+            font_size,
+            t_lock,
+            t_shape,
+            t_layout,
+            total,
+            fragments.len(),
+        );
+        Ok(fragments)
     }
 }

--- a/tests/platform_text_measurer_test.rs
+++ b/tests/platform_text_measurer_test.rs
@@ -34,12 +34,11 @@ fn platform_text_measurer_from_bytes_smoke() {
             font_size: 16.0,
             ..Default::default()
         },
-        max_width: Some(200.0),
-        wrap: true,
     };
 
     let res = pm.measure(&req).expect("measure");
-    println!("measured w={} h={}", res.width, res.height);
-    assert!(res.width > 0.0);
-    assert!(res.height > 0.0);
+    assert!(!res.is_empty(), "expected at least one fragment");
+    println!("measured w={} h={}", res[0].width, res[0].height);
+    assert!(res[0].width > 0.0);
+    assert!(res[0].height > 0.0);
 }


### PR DESCRIPTION
## 概要 / Summary
- Glyphon 依存を削除し、font レンダリングを orinium_text に委譲


## スクリーンショット / Screenshots
<img width="600" alt="image" src="https://github.com/user-attachments/assets/58d725fc-5cfe-4eb9-a139-a3a200a355d4" />


## 備考 / Notes
- カーニングやリガチャは未実装です
