### PR TITLE
Combined patches 4,5,6 #168

### DIFF
--- a/src/browser/core/tab.rs
+++ b/src/browser/core/tab.rs
@@ -165,7 +165,14 @@ impl Tab {
 
         let url = super::webview::resolve_url(base_url, href).unwrap();
 
-        // navigate と同じ扱い
+        if let Some(doc_url) = &self.docment_url {
+            if doc_url.path() == url.path() && url.fragment().is_some() {
+                let fragment = url.fragment().unwrap();
+                log::info!("Scrolling to fragment: {}", fragment);
+                return;
+            }
+        }
+
         self.navigate(url)
     }
 

--- a/src/engine/layouter/builder.rs
+++ b/src/engine/layouter/builder.rs
@@ -235,10 +235,12 @@ pub fn build_layout_and_info(
 
         let layout = LayoutNode::with_children(style, inline_fragments);
 
-        let info = InfoNode {
-            kind,
-            children: vec![],
-        };
+       let info = InfoNode {
+    id: id.clone(), // Добавь эту строку
+    kind,
+    children: vec![],
+};
+
 
         (layout, info)
     } else {
@@ -330,11 +332,12 @@ pub fn build_layout_and_info(
 
         let layout = LayoutNode::with_children(style, layout_children);
 
-        let info = InfoNode {
-            kind,
-            children: info_children,
-        };
-
+       let info = InfoNode {
+    id: id.clone(), // И здесь тоже обязательно добавь
+    kind,
+    children: info_children,
+};
+        
         (layout, info)
     };
 

--- a/src/engine/layouter/types.rs
+++ b/src/engine/layouter/types.rs
@@ -4,6 +4,7 @@
 /// It can be either a Container or Text node, each with its own properties and styles.
 #[derive(Debug, Clone)]
 pub struct InfoNode {
+    pub id: Option<String>, 
     pub kind: NodeKind,
     pub children: Vec<InfoNode>,
 }


### PR DESCRIPTION
patch 4:ファイル src/browser/core/tab.rs では、リンクをクリックした際にブラウザがアンカーを認識できるように、フラグメント（ # ）で URL をインターセプトするロジックが追加されました。
 patch 5:Id: Option<String> フィールドが InfoNode 構造体の src/ engine/layouter/types.rs ファイルに追加されました。これにより、レイアウトツリー内の各ノードがそれぞれ独自のHTML識別子を保存できるようになりました。

patch 6:InfoNode の初期化ロジックが src/ engine/layouter/builder.rs ファイルで更新されました。現在、InfoNodeでレイアウトツリーを構築する際、DOM属性から取得した現在の要素のIDが渡されます。